### PR TITLE
Improve `PimcoreElasticsearchClientBundle::getPath()`

### DIFF
--- a/src/PimcoreElasticsearchClientBundle.php
+++ b/src/PimcoreElasticsearchClientBundle.php
@@ -19,16 +19,8 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 class PimcoreElasticsearchClientBundle extends Bundle
 {
-    /**
-     * {@inheritdoc}
-     */
     public function getPath(): string
     {
-        if (null === $this->path) {
-            $reflected = new \ReflectionObject($this);
-            $this->path = \dirname($reflected->getFileName(), 2);
-        }
-
-        return $this->path;
+        return \dirname(__DIR__);
     }
 }


### PR DESCRIPTION
Implement the method [as Symfony suggests](https://symfony.com/doc/4.4/bundles/best_practices.html#directory-structure). The former code was actually the same as in the parent class. But we don't need auto-discovery here.