### PR TITLE
allow setting of ssl_verification without ssl_key...

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ pimcore_elasticsearch_client:
             ssl_key: 'path/to/ssl/key'
             ssl_cert: 'path/to/ssl/cert'
             ssl_password: 'secretePW'
-            ssl_verification: false #false is the default value
+            ssl_verification: false #true is the default value
             http_options:
                 proxy: 'http://localhost:8125'
             cloud_id: '123456789'

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -63,7 +63,7 @@ class Configuration implements ConfigurationInterface
                             ->info('If private key and certificate require a password (default: null)')
                         ->end()
                         ->booleanNode('ssl_verification')
-                            ->info('Enable or disable the SSL verification (default: false)')
+                            ->info('Enable or disable the SSL verification (default: true)')
                         ->end()
                         ->arrayNode('http_options')
                             ->prototype('scalar')->end()

--- a/src/EsClientFactory.php
+++ b/src/EsClientFactory.php
@@ -45,10 +45,10 @@ class EsClientFactory
             $builder
                 ->setSSLKey($configuration['ssl_key'], $configuration['ssl_password'] ?? null)
                 ->setSSLCert($configuration['ssl_cert'], $configuration['ssl_password'] ?? null);
+        }
 
-            if (isset($configuration['ssl_verification'])) {
-                $builder->setSSLVerification($configuration['ssl_verification']);
-            }
+        if (isset($configuration['ssl_verification'])) {
+            $builder->setSSLVerification($configuration['ssl_verification']);
         }
 
         if (isset($configuration['http_options'])) {


### PR DESCRIPTION
Problem:
- the ssl_verification is not considered if we don't define ssl_key/ssl_cert
- fix docs because the ssl_verification is by default "true"