### PR TITLE
chore: replace @reusable-workflows with @main

### DIFF
--- a/.github/workflows/new-static-analysis.yaml
+++ b/.github/workflows/new-static-analysis.yaml
@@ -15,7 +15,7 @@ on:
 jobs:
   static-analysis-phpstan:
     name: "Static Analysis with PHPStan"
-    uses: pimcore/workflows-collection-public/.github/workflows/reusable-static-analysis-unified.yaml@reusable-workflows
+    uses: pimcore/workflows-collection-public/.github/workflows/reusable-static-analysis-unified.yaml@main
     with:
       phpstan_matrix: >-
         {"include":[{"php-version":"8.4","dependencies":"lowest","experimental":false},{"php-version":"8.5","dependencies":"highest","experimental":false}]}


### PR DESCRIPTION
This PR replaces all occurrences of `@reusable-workflows` with `@main` across the repository.